### PR TITLE
Mushroom feature support and camera lifecycle fix 2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,11 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="com.adamrocker.android.simeji.ACTION_INTERCEPT" />
+                <category android:name="com.adamrocker.android.simeji.REPLACE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity-alias>
 
         <activity


### PR DESCRIPTION
マッシュルーム機能により、IMEからコードを読み取り、直接入力できるようにしました。
単純にintent-filterを追加しただけでは、別インスタンスで起動したカメラが作り直されないため、ライフサイクルを見直しました。